### PR TITLE
fix: properly handle multimodal messages in compat_oai plugin

### DIFF
--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -113,25 +113,38 @@ func (g *ModelGenerator) WithMessages(messages []*ai.Message) *ModelGenerator {
 				oaiMessages = append(oaiMessages, tm)
 			}
 		case ai.RoleUser:
-			oaiMessages = append(oaiMessages, openai.UserMessage(content))
-
-			parts := []openai.ChatCompletionContentPartUnionParam{}
+			// Check if message contains media
+			hasMedia := false
 			for _, p := range msg.Content {
 				if p.IsMedia() {
-					part := openai.ImageContentPart(
-						openai.ChatCompletionContentPartImageImageURLParam{
-							URL: p.Text,
-						})
-					parts = append(parts, part)
-					continue
+					hasMedia = true
+					break
 				}
 			}
-			if len(parts) > 0 {
+
+			if hasMedia {
+				// Build multipart message with both text and media
+				parts := []openai.ChatCompletionContentPartUnionParam{}
+				for _, p := range msg.Content {
+					if p.IsMedia() {
+						part := openai.ImageContentPart(
+							openai.ChatCompletionContentPartImageImageURLParam{
+								URL: p.Text,
+							})
+						parts = append(parts, part)
+					} else if p.IsText() {
+						part := openai.TextContentPart(p.Text)
+						parts = append(parts, part)
+					}
+				}
 				oaiMessages = append(oaiMessages, openai.ChatCompletionMessageParamUnion{
 					OfUser: &openai.ChatCompletionUserMessageParam{
 						Content: openai.ChatCompletionUserMessageParamContentUnion{OfArrayOfContentParts: parts},
 					},
 				})
+			} else {
+				// Simple text message
+				oaiMessages = append(oaiMessages, openai.UserMessage(content))
 			}
 		default:
 			// ignore parts from not supported roles


### PR DESCRIPTION
## Description

This PR fixes a critical bug in the `compat_oai` plugin where multimodal messages (containing both text and images) were being incorrectly processed.

## Problem

When using the compat_oai plugin with messages containing both text and media parts, the implementation was:
1. Always appending a text-only message first (line 116)
2. Then conditionally appending a second message with only media parts (lines 118-135)
3. Ignoring text parts when media was present in the second message

This resulted in:
- Duplicate messages being sent to the OpenAI API
- Loss of text content that accompanies images
- API errors or unexpected behavior when processing multimodal content

## Solution

The fix properly handles multimodal messages by:
1. First checking if a message contains any media parts
2. If media is present, combining both text and media parts into a single multipart message
3. Only using simple text messages when no media is present

## Testing

The fix was tested with:
- Text-only messages (unchanged behavior)
- Image-only messages (now properly handled)
- Combined text + image messages (now correctly combined into single message)

## Impact

This fix enables proper multimodal support for all OpenAI-compatible providers using the compat_oai plugin, including:
- Image analysis and description
- Vision-based Q&A
- Multimodal chat applications

## Example

Before this fix, a message like:
```go
ai.Message{
    Role: ai.RoleUser,
    Content: []*ai.Part{
        ai.NewTextPart("Describe this image"),
        ai.NewMediaPart("image/jpeg", "data:image/jpeg;base64,..."),
    },
}
```

Would be sent as TWO separate messages to the API. Now it's correctly sent as a single multimodal message.