### PR TITLE
fix(compat_oai): correct parameter order in ToolMessage call

### DIFF
--- a/go/plugins/compat_oai/generate.go
+++ b/go/plugins/compat_oai/generate.go
@@ -107,8 +107,8 @@ func (g *ModelGenerator) WithMessages(messages []*ai.Message) *ModelGenerator {
 				}
 
 				tm := openai.ToolMessage(
-					toolCallID,
 					anyToJSONString(p.ToolResponse.Output),
+					toolCallID,
 				)
 				oaiMessages = append(oaiMessages, tm)
 			}


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where tool response messages have their `content` and `tool_call_id` fields swapped in the JSON output when using the OpenAI compatibility layer.

## Problem

When Genkit creates tool response messages, the parameters to `openai.ToolMessage()` were in the wrong order, resulting in:
```json
{
  "role": "tool",
  "content": "tooluse_B8G0zOhpTIKkZKFc_DRtdQ",  // Should be the response data
  "tool_call_id": "{\"conditions\":\"Clear\",...}"  // Should be the tool ID
}
```

This causes validation errors with services like AWS Bedrock that enforce strict validation on `tool_call_id` fields (must match pattern `[a-zA-Z0-9_-]+` and be ≤64 chars).

## Solution

The OpenAI SDK signature for `ToolMessage` is:
```go
func ToolMessage[T string | []ChatCompletionContentPartTextParam](content T, toolCallID string)
```

This PR corrects the parameter order from:
```go
openai.ToolMessage(toolCallID, anyToJSONString(p.ToolResponse.Output))  // Wrong
```

To:
```go
openai.ToolMessage(anyToJSONString(p.ToolResponse.Output), toolCallID)  // Correct
```

## Impact

This fix ensures tool responses are properly formatted according to the OpenAI API specification, making them compatible with strict validation backends like AWS Bedrock.

## Testing

- [x] Verified the parameter order matches [OpenAI SDK documentation](https://github.com/openai/openai-go/blob/5be03675e4eb205101088eb46ce726cb639ef0c9/chatcompletion.go#L1934)
- [x] Tested with tool-calling examples
- [x] Confirmed JSON output has fields in correct positions